### PR TITLE
Project name refactor (closes #120)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#TransitTalk
+## Transit Talk
 
 [![Build Status][build-status-icon]][build-status]
 [![Coverage Status][coverage-status-icon]][coverage-status]

--- a/app/views/lines/index.html.erb
+++ b/app/views/lines/index.html.erb
@@ -8,7 +8,7 @@
 			<%= render "lines/show", line: line %>
 		<% end %>
 	<% else %>
-		<em class="placeholder">There are no lines in this Caravan!</em>
+		<em class="placeholder">There are no lines in this Transit Talk app!</em>
 	<% end %>
 </div>
 

--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -2,15 +2,15 @@
 <div class="page-container">
 	<%= stylesheet_link_tag "home" %>
 
-	<h1>About Caravan</h1>
-	<h4>Caravan is a platform that democratizes the flow of information about issues that riders encounter on public
+	<h1>About Transit Talk</h1>
+	<h4>Transit Talk is a platform that democratizes the flow of information about issues that riders encounter on public
 	transit.<br /><br  />
 	Utilizing the data provided by major transit systems for modern-day navigation tools (namely, GTFS),
-	Caravan allows for developers to easily extend open data for schedules and routes in their city, creating a channel
+	Transit Talk allows for developers to easily extend open data for schedules and routes in their city, creating a channel
 	for productive expression of transit issues. We hope to empower transit riders to take better advantage of transportatation
  	resources, and push for positive changes in their transit systems.</h4>
 
-	<h4>To learn more about the tech behind this project, visit our <a href="https://github.com/CaravanTransit/Caravan-App">GitHub
+	<h4>To learn more about the tech behind this project, visit our <a href="https://github.com/CaravanTransit/Transit-Talk">GitHub
 	repository</a>.</h4></div>
 
 <%= new_issue_button %>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,6 +1,6 @@
 <div class="homepage">
   <div class="hero">
-    <%= image_tag "caravan_logo.svg", class: "logo", alt: "Caravan Logo" %>
+    <%= image_tag "caravan_logo.svg", class: "logo", alt: "Transit Talk Logo" %>
 
     <div class="heading">
       Report and View Public Transit Issues in

--- a/config/app.yml
+++ b/config/app.yml
@@ -2,7 +2,7 @@
 
 # These are the defaults for the site settings
 defaults: &defaults
-  site_name: "Caravan"
+  site_name: "Transit Talk"
   theme_color: "#58b7ff"
   city_name: "Our City"
 


### PR DESCRIPTION
### Description of Changes:
Changes all references to old "Caravan" project name within the app, with the exception of filenames. Additionally, fixes a slight typo in the new "Transit Talk" name on the README.


### How This Was Tested:
Ran app locally to ensure propagation of changes, especially those stemming from the app.yml config file.


### Related Issue(s) or Specifications:
- Closes #120

### Checklist:
- [x] Code follows code style of this project
- [x] Tests added to cover changes
- [x] All new and existing tests passing