### PR TITLE
Add bus? and train? methods to Line model

### DIFF
--- a/app/models/line.rb
+++ b/app/models/line.rb
@@ -19,4 +19,14 @@ class Line < ApplicationRecord
   def short_name
     route_long_name != name ? name : nil
   end
+
+  # GTFS reference says that a "route_type" of 3 indicates a bus line
+  # https://developers.google.com/transit/gtfs/reference/#routestxt
+  def bus?
+    if system_type.nil?     # Prefer system_type if present
+      vehicle_type == "bus"
+    else
+      system_type == 3
+    end
+  end
 end

--- a/app/models/line.rb
+++ b/app/models/line.rb
@@ -29,4 +29,14 @@ class Line < ApplicationRecord
       system_type == 3
     end
   end
+
+  # GTFS reference says that a "route_type" of 0 or 1 indicates a train line
+  # https://developers.google.com/transit/gtfs/reference/#routestxt
+  def train?
+    if system_type.nil?
+      vehicle_type == "tram" || vehicle_type == "metro"
+    else
+      system_type == 0 || system_type == 1
+    end
+  end
 end

--- a/test/models/line_test.rb
+++ b/test/models/line_test.rb
@@ -46,4 +46,30 @@ class LineTest < ActiveSupport::TestCase
     line = Line.new(vehicle_type: "tram")
     refute line.bus?
   end
+
+  test "train? returns true if system type is tram or metro" do
+    line = Line.new(system_type: 0)
+    assert line.train?
+
+    line = Line.new(system_type: 1)
+    assert line.train?
+  end
+
+  test "train? returns true if vehicle type is tram or metro" do
+    line = Line.new(vehicle_type: "tram")
+    assert line.train?
+
+    line = Line.new(vehicle_type: "metro")
+    assert line.train?
+  end
+
+  test "train? returns false if system type is not tram or metro" do
+    line = Line.new(system_type: 3, vehicle_type: "tram")
+    refute line.train?
+  end
+
+  test "train? returns false if system type is nil and vehicle type is wrong" do
+    line = Line.new(vehicle_type: "bus")
+    refute line.train?
+  end
 end

--- a/test/models/line_test.rb
+++ b/test/models/line_test.rb
@@ -72,4 +72,10 @@ class LineTest < ActiveSupport::TestCase
     line = Line.new(vehicle_type: "bus")
     refute line.train?
   end
+
+  test "line with no vehicle or system type is not bus? or train?" do
+    line = Line.new
+    refute line.bus?
+    refute line.train?
+  end
 end

--- a/test/models/line_test.rb
+++ b/test/models/line_test.rb
@@ -28,4 +28,22 @@ class LineTest < ActiveSupport::TestCase
     line = Line.new(route_long_name: route_long_name)
     assert_nil line.short_name, "Failed to return correct route short name"
   end
+
+  test "bus? returns true if system type or vehicle type indicates bus" do
+    line = Line.new(vehicle_type: "bus")
+    assert line.bus?
+
+    line = Line.new(system_type: 3)
+    assert line.bus?
+  end
+
+  test "bus? returns false if system type is not bus type" do
+    line = Line.new(system_type: 1, vehicle_type: "bus")
+    refute line.bus?
+  end
+
+  test "bus? returns false if system type is nil and vehicle type is not bus" do
+    line = Line.new(vehicle_type: "tram")
+    refute line.bus?
+  end
 end

--- a/test/models/line_test.rb
+++ b/test/models/line_test.rb
@@ -39,12 +39,12 @@ class LineTest < ActiveSupport::TestCase
 
   test "bus? returns false if system type is not bus type" do
     line = Line.new(system_type: 1, vehicle_type: "bus")
-    refute line.bus?
+    assert_not line.bus?
   end
 
   test "bus? returns false if system type is nil and vehicle type is not bus" do
     line = Line.new(vehicle_type: "tram")
-    refute line.bus?
+    assert_not line.bus?
   end
 
   test "train? returns true if system type is tram or metro" do
@@ -65,17 +65,17 @@ class LineTest < ActiveSupport::TestCase
 
   test "train? returns false if system type is not tram or metro" do
     line = Line.new(system_type: 3, vehicle_type: "tram")
-    refute line.train?
+    assert_not line.train?
   end
 
   test "train? returns false if system type is nil and vehicle type is wrong" do
     line = Line.new(vehicle_type: "bus")
-    refute line.train?
+    assert_not line.train?
   end
 
   test "line with no vehicle or system type is not bus? or train?" do
     line = Line.new
-    refute line.bus?
-    refute line.train?
+    assert_not line.bus?
+    assert_not line.train?
   end
 end


### PR DESCRIPTION
This is a first step toward addressing https://github.com/CaravanTransit/Transit-Talk/issues/119. 

### Description of Changes:
This PR adds two new methods to the `Line` model for figuring out whether the line is a bus line or train line.

This distinction seems pretty important and I want to make sure I've got it right.

The code I've written prefers `system_type` to `vehicle_type` when deciding whether a line is a bus line or train line. Also, I've assumed that a train line is either a "tram line" or a "metro line" as defined by GTFS. 

### How This Was Tested:
Added several tests to the `Line` model unit test file.

### Related Issue(s) or Specifications:
- #119 

### Checklist:
- [x] Code follows code style of this project
- [x] Tests added to cover changes
- [x] All new and existing tests passing