### PR TITLE
Add schema annotations to models

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,9 @@ gem 'rails', '~> 5.0.2'
 group :development, :test do
 	# SQLite, only on local
 	gem 'sqlite3'
+
+  # Annotate model files with db schema
+  gem 'annotate'
 end
 
 # Use devise here for db management

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,9 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    annotate (2.7.4)
+      activerecord (>= 3.2, < 6.0)
+      rake (>= 10.4, < 13.0)
     arel (7.1.4)
     ast (2.4.0)
     bcrypt (3.1.11)
@@ -281,6 +284,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-import
+  annotate
   byebug
   coffee-rails (~> 4.2)
   coveralls
@@ -317,4 +321,4 @@ RUBY VERSION
    ruby 2.4.4p296
 
 BUNDLED WITH
-   1.16.3
+   2.0.1

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -1,5 +1,22 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: issues
+#
+#  id              :integer          not null, primary key
+#  stop_onestop_id :string
+#  vehicle_id      :integer
+#  description     :text
+#  user_id         :integer
+#  line_onestop_id :string
+#  types           :string
+#  resolved        :boolean
+#  created_at      :datetime
+#  updated_at      :datetime
+#
+
+
 class Issue < ApplicationRecord
   belongs_to :user
   belongs_to :stop, foreign_key: "stop_onestop_id"

--- a/app/models/line.rb
+++ b/app/models/line.rb
@@ -1,5 +1,21 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: lines
+#
+#  id                    :integer          not null
+#  route_long_name       :string
+#  name                  :string
+#  system_type           :integer
+#  color                 :string
+#  onestop_id            :string           primary key
+#  vehicle_type          :string
+#  wheelchair_accessible :string
+#  bikes_allowed         :string
+#
+
+
 class Line < ApplicationRecord
   has_many :issues, foreign_key: "line_onestop_id"
   has_and_belongs_to_many :stops,

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -1,5 +1,19 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: settings
+#
+#  id         :integer          not null, primary key
+#  var        :string           not null
+#  value      :text
+#  thing_id   :integer
+#  thing_type :string(30)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+
 # RailsSettings Model
 class Setting < RailsSettings::Base
   source Rails.root.join("config/app.yml")

--- a/app/models/stop.rb
+++ b/app/models/stop.rb
@@ -1,5 +1,19 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: stops
+#
+#  id           :integer          not null
+#  api_id       :string
+#  name         :string
+#  longitude    :decimal(12, 8)
+#  lattitude    :decimal(12, 8)
+#  twin_stop_id :integer
+#  onestop_id   :string           primary key
+#
+
+
 class Stop < ApplicationRecord
   has_many :issues, foreign_key: "stop_onestop_id"
   has_and_belongs_to_many :lines,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,26 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :integer          not null, primary key
+#  email                  :string           default(""), not null
+#  encrypted_password     :string           default(""), not null
+#  reset_password_token   :string
+#  reset_password_sent_at :datetime
+#  remember_created_at    :datetime
+#  sign_in_count          :integer          default(0), not null
+#  current_sign_in_at     :datetime
+#  last_sign_in_at        :datetime
+#  current_sign_in_ip     :string
+#  last_sign_in_ip        :string
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  admin                  :boolean
+#
+
+
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable

--- a/app/models/vehicle.rb
+++ b/app/models/vehicle.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: vehicles
+#
+#  id      :integer          not null, primary key
+#  api_id  :string
+#  line_id :integer
+#
+
+
 class Vehicle < ApplicationRecord
   belongs_to :line
 end

--- a/lib/tasks/annotate.rake
+++ b/lib/tasks/annotate.rake
@@ -1,0 +1,4 @@
+desc 'Update model file schema annotations'
+task :annotate do
+  sh 'annotate --exclude tests,fixtures,factories,serializers'
+end


### PR DESCRIPTION
This PR adds a Rake task and some auto-generated comments to the model files.

The [annotate gem](https://github.com/ctran/annotate_models) is a handy tool I've used in the past that automatically annotates your model files with the schema of the backing table for the model.

IMO, this is really handy. Figure it could help, since it seems like people keep forgetting what's in the DB.