### PR TITLE
Add migration and rake task for banning users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: users

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 # == Schema Information
 #
 # Table name: users
@@ -18,8 +17,8 @@
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #  admin                  :boolean
+#  is_banned              :boolean          default(FALSE), not null
 #
-
 
 class User < ApplicationRecord
   # Include default devise modules. Others available are:

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,4 +27,12 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :trackable, :validatable
   has_many :issues
   has_and_belongs_to_many :favorites, class_name: "Stop", association_foreign_key: "stop_onestop_id"
+
+  def self.ban_user!(email)
+    u = User.find_by_email(email)
+    if u.present?
+      u.is_banned = true
+      u.save
+    end
+  end
 end

--- a/db/migrate/20190410182147_add_ban_flag_to_user.rb
+++ b/db/migrate/20190410182147_add_ban_flag_to_user.rb
@@ -1,0 +1,5 @@
+class AddBanFlagToUser < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :is_banned, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170913013817) do
+ActiveRecord::Schema.define(version: 20190410182147) do
 
   create_table "issues", force: :cascade do |t|
     t.string   "stop_onestop_id"
@@ -76,19 +76,20 @@ ActiveRecord::Schema.define(version: 20170913013817) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",                  default: "", null: false
-    t.string   "encrypted_password",     default: "", null: false
+    t.string   "email",                  default: "",    null: false
+    t.string   "encrypted_password",     default: "",    null: false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,  null: false
+    t.integer  "sign_in_count",          default: 0,     null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.string   "current_sign_in_ip"
     t.string   "last_sign_in_ip"
-    t.datetime "created_at",                          null: false
-    t.datetime "updated_at",                          null: false
+    t.datetime "created_at",                             null: false
+    t.datetime "updated_at",                             null: false
     t.boolean  "admin"
+    t.boolean  "is_banned",              default: false, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/lib/tasks/ban.rake
+++ b/lib/tasks/ban.rake
@@ -1,0 +1,10 @@
+desc 'Bans the user with the given email.'
+task :ban_user, [:email] => [:environment] do |task, args|
+  email = args[:email]
+
+  if email.present?
+    User.ban_user!(email)
+  else
+    $stderr.puts 'Please provide an email!'
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -4,23 +4,23 @@ require "test_helper"
 
 class UserTest < ActiveSupport::TestCase
   setup do
-    User.create(email: 'badperson@gmail.com',
-                password: 'reallysecure',
-                password_confirmation: 'reallysecure')
+    User.create(email: "badperson@gmail.com",
+                password: "reallysecure",
+                password_confirmation: "reallysecure")
   end
 
-  test 'banning user bans correct user' do
-    user = User.find_by_email('badperson@gmail.com')
+  test "banning user bans correct user" do
+    user = User.find_by_email("badperson@gmail.com")
     assert_not user.is_banned
 
-    User.ban_user!('badperson@gmail.com')
+    User.ban_user!("badperson@gmail.com")
 
     user.reload
     assert user.is_banned
   end
 
-  test 'banning ignores bad email and does not throw error' do
-    User.ban_user!('notauser@gmail.com')
-    User.ban_user!('')
+  test "banning ignores bad email and does not throw error" do
+    User.ban_user!("notauser@gmail.com")
+    User.ban_user!("")
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -3,7 +3,24 @@
 require "test_helper"
 
 class UserTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  setup do
+    User.create(email: 'badperson@gmail.com',
+                password: 'reallysecure',
+                password_confirmation: 'reallysecure')
+  end
+
+  test 'banning user bans correct user' do
+    user = User.find_by_email('badperson@gmail.com')
+    assert_not user.is_banned
+
+    User.ban_user!('badperson@gmail.com')
+
+    user.reload
+    assert user.is_banned
+  end
+
+  test 'banning ignores bad email and does not throw error' do
+    User.ban_user!('notauser@gmail.com')
+    User.ban_user!('')
+  end
 end


### PR DESCRIPTION
### Description of Changes:
This adds a new database field to the user table that records whether or not a user has been banned. For now, a user can easily be banned using a new Rake task that takes an email address and bans the corresponding user.


### How This Was Tested:
There are tests for the ban method on the User class.

### Related Issue(s) or Specifications:
Still to come: Rejecting login attempts for banned users.

### Checklist:
- [ x] Code follows code style of this project
- [x ] Tests added to cover changes
- [x ] All new and existing tests passing

### Questions / Additional Notes:
